### PR TITLE
Add support for `-limit` option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.13
+        go-version: 1.21
     - uses: actions/checkout@v4
     - run: go build


### PR DESCRIPTION
Add new option to set a limit of how many messages to move to destination queue

     Usage of sqsmv:
       -clients int
             number of clients (default 1)
       -dest string
             destination queue
       -limit int
             limit number of messages moved (default -1)
       -src string
             source queue

Use atomic.Int64 to keep a global counter for messages moved and
exit after printing the total number of messages moved

Use Mutex to lock before message is sent to the destination queue,
and remove the client limit when used in combination with `-limit`
